### PR TITLE
feat: increase limit for the content

### DIFF
--- a/src/main/java/dev/kcterala/tunnelx/ServerInitializer.java
+++ b/src/main/java/dev/kcterala/tunnelx/ServerInitializer.java
@@ -12,6 +12,8 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
 public class ServerInitializer extends ChannelInitializer<SocketChannel> {
+    /** Maximum payload size (8 MiB) allowed for HTTP aggregation and WebSocket frames. */
+    private static final int MAX_MESSAGE_SIZE_BYTES = 8 * 1024 * 1024;
     private final TunnelManager tunnelManager;
     
     public ServerInitializer(final TunnelManager tunnelManager) {
@@ -24,14 +26,14 @@ public class ServerInitializer extends ChannelInitializer<SocketChannel> {
         
         // HTTP codec
         pipeline.addLast(new HttpServerCodec());
-        pipeline.addLast(new HttpObjectAggregator(1048576));
+        pipeline.addLast(new HttpObjectAggregator(MAX_MESSAGE_SIZE_BYTES));
         pipeline.addLast(new ChunkedWriteHandler());
         
         // Custom handler for routing
         pipeline.addLast(new HttpRequestHandler(tunnelManager));
         
         // WebSocket handler for tunnel connections
-        pipeline.addLast(new WebSocketServerProtocolHandler("/tunnel", null, true, 1048576));
+        pipeline.addLast(new WebSocketServerProtocolHandler("/tunnel", null, true, MAX_MESSAGE_SIZE_BYTES));
         pipeline.addLast(new WebSocketHandler(tunnelManager));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum supported size for HTTP messages and WebSocket frames from 1 MB to 8 MB, allowing for the transfer of larger data payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->